### PR TITLE
add grayscale theme

### DIFF
--- a/grayscale.py
+++ b/grayscale.py
@@ -1,0 +1,3 @@
+import kplot.lib
+
+kplot.lib.loadtheme("grayscale")

--- a/styles/grayscale.mplstyle
+++ b/styles/grayscale.mplstyle
@@ -1,7 +1,7 @@
 #grayscale: no colors allowed here
 
-font.family                 : sans-serif
-font.sans-serif             : DejaVu Sans
+font.family                 : serif
+font.sans-serif             : Garamond
 
 image.cmap                  : cividis
 

--- a/styles/grayscale.mplstyle
+++ b/styles/grayscale.mplstyle
@@ -1,0 +1,58 @@
+#grayscale: no colors allowed here
+
+font.family                 : sans-serif
+font.sans-serif             : DejaVu Sans
+
+image.cmap                  : cividis
+
+axes.titlesize              : 14
+axes.labelsize              : 10
+axes.edgecolor              : (0.3,0.3,0.3)
+axes.labelcolor             : (0.3,0.3,0.3)
+axes.linewidth              : 1
+axes.spines.top             : False
+axes.spines.right           : False
+axes.spines.bottom          : True
+axes.spines.left            : True
+
+axes.prop_cycle             : cycler('linestyle', ['-', '--', ':', '-.']) * cycler('color', [ '999999', '000000' ])
+
+
+axes.grid                   : True
+grid.alpha                  : 0.3
+grid.linestyle              : --
+grid.linewidth              : 0.6
+
+# LINES
+lines.linewidth             : 1.
+lines.markeredgewidth       : 0.0
+lines.markersize            : 5
+
+lines.solid_joinstyle       : round
+lines.solid_capstyle        : round
+
+# DASHES
+lines.dash_capstyle         : round
+lines.dash_joinstyle        : round
+
+lines.dashed_pattern        : 3.7, 3.5
+lines.dashdot_pattern       : 6.4, 3, 1, 3
+lines.dotted_pattern        : 1, 2.8
+
+
+xtick.labelsize             : 10
+xtick.color                 : (0.3,0.3,0.3)
+xtick.direction             : in
+ytick.labelsize             : 10
+ytick.color                 : (0.3,0.3,0.3)
+ytick.direction             : in
+
+figure.figsize              : 5,5
+figure.dpi                  : 150
+figure.titlesize            : 15
+
+scatter.marker              : .
+
+savefig.dpi                 : 300
+savefig.transparent         : True
+savefig.format              : png


### PR DESCRIPTION
Exactly what it says on the tin: no colors and only grayscale lines. This one can plot up to eight lines before repeating itself, by using a combination of dash types and gray lines. For plots to be printed on a grayscale printer, this type of plot may be the clearest.

![grayscale](https://user-images.githubusercontent.com/23445929/77392886-2ba56d00-6d59-11ea-81bb-3c9e9a731857.png)

P.S. I guess this is what we do during the apocalypse